### PR TITLE
Improve performance and fix handle leak

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
-
 FIND_PACKAGE(Iconv REQUIRED)
+FIND_PACKAGE(Boost 1.55.0 COMPONENTS filesystem iostreams system REQUIRED)
 
-INCLUDE_DIRECTORIES("${PROJECT_SOURCE_DIR}/libendian/src" ${ICONV_INCLUDE_DIR})
+INCLUDE_DIRECTORIES("${PROJECT_SOURCE_DIR}/libendian/src" ${ICONV_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 
 ADD_LIBRARY(mygettext mygettext.cpp mygettext.h gettext.cpp gettext.h)
 
-TARGET_LINK_LIBRARIES(mygettext endian ${ICONV_LIBRARY})
+TARGET_LINK_LIBRARIES(mygettext endian ${ICONV_LIBRARY} ${Boost_LIBRARIES})
 
 #################################################################################

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -39,12 +39,16 @@ class GetText
         void loadCatalog();
 
     private:
+        void unloadCatalog();
+        std::string getCatalogFilePath();
+
         std::string catalog_;
         std::string directory_;
         std::string locale_;
         std::string codepage_;
-        std::map<std::string, std::string> stack_;
-        std::string lastcatalog_;
+        std::map<std::string, std::string> entries_;
+        std::string curCatalogFilePath_;
+        bool isLoaded;
         iconv_t iconv_cd_;
 };
 


### PR DESCRIPTION
This uses now the easier-to-use `EndianStream` during load and more effective checks during use.

The old implementation was actually looking for the catalog-file on every string access trying multiple variations. This is now a simple, inline bool check which serves the same purpose.
`stack_` was renamed to the more appropriate `entries_`
Also there was a new file handle opened on every string access which is never closed.

TLDR: Faster on load and usage, no leaks.

@Flow86 Can you double-check that this is ok? Tested it for German and English.