### PR TITLE
Revert "Build as a static library"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ FIND_PACKAGE(Boost 1.55.0 COMPONENTS filesystem iostreams system REQUIRED)
 
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR} ${ICONV_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 
-ADD_LIBRARY(mygettext STATIC mygettext.cpp mygettext.h gettext.cpp gettext.h)
+ADD_LIBRARY(mygettext mygettext.cpp mygettext.h gettext.cpp gettext.h)
 
 TARGET_LINK_LIBRARIES(mygettext endian ${ICONV_LIBRARY} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
Reverts Return-To-The-Roots/mygettext#5

fixes https://github.com/Return-To-The-Roots/s25client/issues/675

TODO: mygettext has to be installed correctly