### PR TITLE
FIX: install shared mygettext library into RTTR_LIBDIR correctly and …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,10 @@ FIND_PACKAGE(Boost 1.55.0 COMPONENTS filesystem iostreams system REQUIRED)
 
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR} ${ICONV_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 
-ADD_LIBRARY(mygettext mygettext.cpp mygettext.h gettext.cpp gettext.h)
+ADD_LIBRARY(mygettext SHARED mygettext.cpp mygettext.h gettext.cpp gettext.h)
 
 TARGET_LINK_LIBRARIES(mygettext endian ${ICONV_LIBRARY} ${Boost_LIBRARIES})
+
+INSTALL(TARGETS mygettext RUNTIME DESTINATION ${RTTR_LIBDIR})
 
 #################################################################################


### PR DESCRIPTION
…force it to be a shared library

fixes: https://github.com/Return-To-The-Roots/s25client/issues/675, https://github.com/Return-To-The-Roots/mygettext/pull/5