### PR TITLE
Automatic fixes of clang-tidy warnings: misc-unused-using-decls,moder…

### DIFF
--- a/include/mygettext/mygettext.h
+++ b/include/mygettext/mygettext.h
@@ -38,7 +38,7 @@ inline const char* _(const std::string& txt)
     return gettext(txt.c_str());
 }
 /// Return unmodified string (used when translation is done at other place, e.g. string constants)
-inline constexpr MGT_FORMAT_ARG(1) const char* gettext_noop(const char* const str)
+constexpr MGT_FORMAT_ARG(1) const char* gettext_noop(const char* const str)
 {
     return str;
 }

--- a/src/readCatalog.cpp
+++ b/src/readCatalog.cpp
@@ -99,7 +99,7 @@ std::map<std::string, std::string> readCatalog(const std::string& catalogFilepat
     {
         file.seekg(static_cast<std::streampos>(entryDescriptor.keyOffset));
         entryDescriptor.key.resize(entryDescriptor.keyLen);
-        if(!file.read(&entryDescriptor.key[0], entryDescriptor.keyLen))
+        if(!file.read(entryDescriptor.key.data(), entryDescriptor.keyLen))
             throw std::runtime_error("Failed to read key");
     }
 
@@ -137,7 +137,7 @@ std::map<std::string, std::string> readCatalog(const std::string& catalogFilepat
 
             std::string& entry = entries[entryDescriptor.key];
             entry.resize(entryDescriptor.valueLen);
-            if(!file.read(&entry[0], entryDescriptor.valueLen))
+            if(!file.read(entry.data(), entryDescriptor.valueLen))
                 throw std::runtime_error("Failed to read entry");
         }
     }


### PR DESCRIPTION
…nize-use-auto,performance-inefficient-vector-operation,performance-move-const-arg,readability-container-size-empty,readability-redundant-member-init,performance-noexcept-swap,readability-redundant-inline-specifier,readability-container-data-pointer